### PR TITLE
Fix bulleted list styling

### DIFF
--- a/sass/_nbis.scss
+++ b/sass/_nbis.scss
@@ -84,6 +84,15 @@ nav {
     background-color: white;
     padding-bottom: 64px;
     margin-bottom: 64px;
+    ul {
+        margin-left: 1.2rem;
+        li {
+            list-style-type: disc;
+        }
+    }
+    dl {
+        margin-left:10px;
+    }
 }
 
 .dropdown-content li > a, .dropdown-content li > span {


### PR DESCRIPTION
The sidebar toc disabled bulleted list styling for the main content.
This happened because the CSS-class that applies this styling (.bread)
was removed from the main content div. This PR adds the styling back,
but I think we can remove the .bread class in the future.